### PR TITLE
LiveReloadHelp goes to a working site

### DIFF
--- a/CommandAPI.py
+++ b/CommandAPI.py
@@ -19,7 +19,7 @@ class LiveReloadTest(sublime_plugin.ApplicationCommand):
 class LiveReloadHelp(sublime_plugin.ApplicationCommand):
 
     def run(self):
-        webbrowser.open_new_tab('https://github.com/dz0ny/LiveReload-sublimetext2/'
+        webbrowser.open_new_tab('https://github.com/alepez/LiveReload-sublimetext3#using'
                                 )
 
 


### PR DESCRIPTION
The previous url does not exist anymore.
Furthermore, linking to `alepez/LiveReload-sublimetext3` is more appropriate.