### PR TITLE
[Fixed] Unexpected output in console after file save

### DIFF
--- a/server/LiveReloadAPI.py
+++ b/server/LiveReloadAPI.py
@@ -11,7 +11,7 @@ except ValueError:
 from functools import wraps
 
 def log(msg):
-  print(msg)
+  # print(msg)
 
 class LiveReloadAPI(object):
 


### PR DESCRIPTION
### 1. Settings

My `User\LiveReload.sublime-settings` file:

```json
{
     "enabled_plugins":
     [
     "SimpleReloadPlugin",
     "SimpleRefresh"
     ]
}

```

### 2. Behavior before pull request

I don't apply LiveReload at the moment → I save any file → I get output in Sublime Text console after each file save, for example:

```json
{"command": "reload", "apply_images_live": null, "apply_css_live": null, "apply_js_live": null, "path": "test.md"}
```

I don't want get this output in console, it prevents me in debugging process. See [**similar issue**](https://github.com/akalongman/sublimetext-codeformatter/issues/282).

### 3. Behavior after pull request

I don't get output in console after file save.

### 4. Feature request

I think, that this output may be necessary, if user use LiveReload at the moment — if LiveReload apply in browser. But if user don't use LiveReload at the moment, this output unexpected.


Thanks.