### PR TITLE
Allow enable/disable/toggle plugin by command directly

### DIFF
--- a/CommandAPI.py
+++ b/CommandAPI.py
@@ -32,3 +32,27 @@ class LiveReloadEnablePluginCommand(sublime_plugin.ApplicationCommand):
     def run(self):
         sublime.active_window().show_quick_panel(LiveReload.Plugin.listPlugins(),
                 self.on_done)
+
+
+class LiveReloadConfigPluginCommand(sublime_plugin.ApplicationCommand):
+    def run(self, plugin=None, operation="noop"):
+        if not isinstance(plugin, str):
+            return
+
+        plugin_names = [p.__name__ for p in LiveReload.Plugin.plugins]
+        # print("Available plugins: ", plugin_names)
+
+        try:
+            index = plugin_names.index(plugin)
+        except ValueError:
+            sublime.error_message("Plugin not found: " + plugin)
+            return
+
+        p = LiveReload.Plugin.getPlugin(plugin)
+
+        if (
+            operation == "toggle"
+            or (operation == "enable" and not p.isEnabled)
+            or (operation == "disable" and p.isEnabled)
+        ):
+            LiveReload.Plugin.togglePlugin(index)


### PR DESCRIPTION
For example, the following becomes possible.

```jsonc
{
    "keys": ["f7"],
    "command": "live_reload_config_plugin",
    "args": { "plugin": "SimpleRefreshDelay", "operation": "enable" }
}
```

---

I actually use this with

- https://packagecontrol.io/packages/Chain%20of%20Command
- https://packagecontrol.io/packages/MarkdownPreview

to get markdown previewed with a single keybinding.

I feel a little annoyed to turn on `SimpleRefreshDelay` every time after ST restarts. The following example keybinding turns it on for me before doing a markdown preview.

```jsonc
// plugin: LiveReload + MarkdownPreview
{
    "keys": ["alt+m", "alt+p"],
    "command": "chain",
    "args": {
        "commands": [
            [ "live_reload_config_plugin", { "plugin": "SimpleRefreshDelay", "operation": "enable" } ],
            [ "markdown_preview", { "target": "browser", "parser": "markdown" } ],
        ],
    },
    "context": [ { "key": "selector", "operator": "equal", "operand": "text.html.markdown" } ],
},
```