### PR TITLE
fix: fail decoding ST's settings if it has trailing commas

### DIFF
--- a/CompassPlugin.py
+++ b/CompassPlugin.py
@@ -1,6 +1,7 @@
 #!/usr/bin/python
 # -*- coding: utf-8 -*-
 
+from .server.Settings import read_sublime_settings
 import os
 import threading
 import subprocess
@@ -94,7 +95,7 @@ class CompassThread(threading.Thread):
     def run(self):
         dirname = self.dirname
         if not self.check_for_compass_config():
-            if json.load(open(os.path.join(sublime.packages_path(),'LiveReload','CompassPlugin.sublime-settings')))["create_configrb"]:
+            if read_sublime_settings(os.path.join(sublime.packages_path(),'LiveReload','CompassPlugin.sublime-settings'))["create_configrb"]:
                 self.generate_conf_rb(dirname)
             else:
                 sublime.error_message("Could not find Compass config.rb. Please check your sublime-project file and adjust settings accordingly!")

--- a/SassPlugin.py
+++ b/SassPlugin.py
@@ -1,6 +1,7 @@
 #!/usr/bin/python
 # -*- coding: utf-8 -*-
 
+from .server.Settings import read_sublime_settings
 import os
 import threading
 import subprocess
@@ -31,12 +32,12 @@ class SassThread(threading.Thread):
             self.dirname = dirname.replace('\\', '/')
 
         # default config
-        self.config = json.load(open(os.path.join(sublime.packages_path(),'LiveReload','SassPlugin.sublime-settings')))
+        self.config = read_sublime_settings(os.path.join(sublime.packages_path(),'LiveReload','SassPlugin.sublime-settings')) or {}
 
         # check for local config
         localConfigFile = os.path.join(self.dirname, "sass_config.json");
         if os.path.isfile(localConfigFile):
-            localConfig = json.load(open(localConfigFile))
+            localConfig = read_sublime_settings(localConfigFile)
             self.config.update(localConfig)
 
         try:

--- a/server/Settings.py
+++ b/server/Settings.py
@@ -13,6 +13,14 @@ except Exception as e:
     log(e)
 
 
+def read_sublime_settings(file_path):
+    try:
+        with open(file_path, 'r', encoding='utf-8') as f:
+            return sublime.decode_value(f.read())
+    except (IOError, ValueError):
+        return None
+
+
 class Settings(dict):
 
     def __init__(self):
@@ -21,24 +29,18 @@ class Settings(dict):
             cdir = os.path.dirname(os.path.abspath(__file__))
             if not "LiveReload" in cdir:
                 cdir = os.path.join(sublime.packages_path(), 'LiveReload')
-            self.file_name = os.path.join(cdir, '..', 'LiveReload.sublime-settings');
-            file_object = open(self.file_name)
-            data = json.load(file_object)
-            file_object.close()
+            self.file_name = os.path.join(cdir, '..', 'LiveReload.sublime-settings')
+            data = read_sublime_settings(self.file_name) or {}
 
             # Merging user settings
-            user = os.path.join(cdir, '..' , '..', 'User', 'LiveReload.sublime-settings');
-            data_user = []
-            if os.path.exists(user):
-                user_file = open(user)
-                data_user = json.load(user_file)
-                user_file.close()
+            user = os.path.join(cdir, '..', '..', 'User', 'LiveReload.sublime-settings')
+            data_user = read_sublime_settings(user) or {}
 
             for i in data:
                 self[i] = data[i]
 
             for i in data_user:
-                print(i)
+                log(i)
                 self[i] = data_user[i]
             log('LiveReload: Settings loaded')
             log('-----------')


### PR DESCRIPTION
I just wonder why my settings never work and find this...

To properly decode ST's settings file, which allows comments and trailing commas, you must use `sublime.decode_value()`. 