### PR TITLE
fix py38 syntax warning

### DIFF
--- a/CommandAPI.py
+++ b/CommandAPI.py
@@ -26,7 +26,7 @@ class LiveReloadHelp(sublime_plugin.ApplicationCommand):
 class LiveReloadEnablePluginCommand(sublime_plugin.ApplicationCommand):
 
     def on_done(self, index):
-        if not index is -1:
+        if index != -1:
             LiveReload.Plugin.togglePlugin(index)
 
     def run(self):

--- a/LiveReload.py
+++ b/LiveReload.py
@@ -99,7 +99,7 @@ class LiveReload(threading.Thread, SimpleCallbackServer,
         self.ws_server.stop()
 
 
-if not sublime.platform is 'build':
+if sublime.platform != 'build':
     try:
         sys.modules['LiveReload'].API
     except Exception:

--- a/server/PluginAPI.py
+++ b/server/PluginAPI.py
@@ -80,7 +80,7 @@ class PluginFactory(type):
         file_types = []
         for plugin in mcs.plugins:
             if plugin.__name__ in mcs.enabled_plugins:
-                if not plugin.file_types is '*':
+                if plugin.file_types != '*':
                     for ext in plugin.file_types.split(','):
                         file_types.append(ext)
         return file_types
@@ -162,7 +162,7 @@ class PluginClass:
 
             if [f for f in this_plugin if filename.endswith(f)]:
                 return True
-            elif self.file_types is '*' and otherPluginsWithFilter():
+            elif self.file_types == '*' and otherPluginsWithFilter():
                 return True
             else:
                 return False
@@ -197,7 +197,7 @@ class PluginClass:
         """
 
         if self.isEnabled:
-            if command is 'refresh':  # to support new protocol
+            if command == 'refresh':  # to support new protocol
                 settings['command'] = 'reload'
             try:
                 if not filename:


### PR DESCRIPTION
ST 4193 introduces a new setting:

- Added <tt>"disable_plugin_host_3.3"</tt> setting. This causes all plugins to run under 3.8

While running this plugin under python 3.8, ST console shows

```
sublime_text\Data\Packages\LiveReload\LiveReload.py:102: SyntaxWarning: "is not" with a literal. Did you mean "!="?
  if not sublime.platform is 'build':
sublime_text\Data\Packages\LiveReload\server\PluginAPI.py:83: SyntaxWarning: "is not" with a literal. Did you mean "!="?
  if not plugin.file_types is '*':
sublime_text\Data\Packages\LiveReload\server\PluginAPI.py:165: SyntaxWarning: "is" with a literal. Did you mean "=="?
  elif self.file_types is '*' and otherPluginsWithFilter():
sublime_text\Data\Packages\LiveReload\server\PluginAPI.py:200: SyntaxWarning: "is" with a literal. Did you mean "=="?
  if command is 'refresh':  # to support new protocol
enabled_plugins
LiveReload: added file /livereload.js with content-type: text/javascript
reloading plugin LiveReload.CoffeescriptPlugin
enabled_plugins
INFO:WebSocketClient:Starting server
reloading plugin LiveReload.CommandAPI
sublime_text\Data\Packages\LiveReload\CommandAPI.py:29: SyntaxWarning: "is not" with a literal. Did you mean "!="?
  if not index is -1:
```

This PR fixes those warnings.